### PR TITLE
Fix CI by specifying the Elm versions explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: elm
-elm: elm0.19.0
-elm-test: 0.19.0
-elm-format: 0.8.1
+
+install:
+  - npm install -g elm@0.19.1-3
+  - npm install -g elm-test@0.19.1
+  - npm install -g elm-format@0.8.2


### PR DESCRIPTION
The Elm version can not be set with the default Travis CI image, so we'll use NPM directly to set them up. This might slow down the builds a tiny bit.