### PR TITLE
Fix issue with yarn deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>heig-PRO-b04</title>
   </head>
   <body>
-    <div id="elm"></div>
+    <main></main>
     <script src="./index.js"></script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@ import { Elm } from "./src/Main.elm";
 
 // Maybe we will want to pass the API endpoint in the program flags.
 const app = Elm.Main.init({
-  node: document.getElementById("elm")
+  node: document.querySelector("main")
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "test": "elm-format --validate . && elm-test",
     "dev": "parcel index.html",
-    "build": "parcel build index.html"
+    "build": "parcel build index.html --public-url ./"
   },
   "devDependencies": {
     "elm": "^0.19.1-3",

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,8 +1,57 @@
 module Main exposing (main)
 
-import Html exposing (Html, text)
+import Browser
+import Html exposing (Html, button, div, text)
+import Html.Events exposing (onClick)
 
 
-main : Html ()
+type alias Counter =
+    Int
+
+
+type Message
+    = Decrement
+    | Increment
+
+
+init : () -> ( Counter, Cmd Message )
+init _ =
+    ( 42, Cmd.none )
+
+
+subscriptions : Counter -> Sub Message
+subscriptions _ =
+    Sub.none
+
+
+update : Message -> Counter -> ( Counter, Cmd Message )
+update msg counter =
+    let
+        value =
+            case msg of
+                Decrement ->
+                    counter - 1
+
+                Increment ->
+                    counter + 1
+    in
+    ( value, Cmd.none )
+
+
+view : Counter -> Html Message
+view counter =
+    div []
+        [ button [ onClick Increment ] [ text "+" ]
+        , text <| String.fromInt counter
+        , button [ onClick Decrement ] [ text "-" ]
+        ]
+
+
+main : Program () Counter Message
 main =
-    text "Hello world."
+    Browser.element
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }


### PR DESCRIPTION
This closes #4.

Parcel had some issues bundling the application because not all URLs
were set public.

On top of that, we changed the core application to be a simple counter,
to already have a basic Elm architecture in place.