### PR TITLE
Add a build shield to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # heig-PRO-b04/elm-frontend
 
+[![Build Status](https://travis-ci.com/heig-PRO-b04/elm-frontend.svg?branch=master)](https://travis-ci.com/heig-PRO-b04/elm-frontend)
+
 Hello world ! This project is still being set up.


### PR DESCRIPTION
This is mostly for fun, and bringing a bit of color to the README.md of
the repository. The build shield will only reflect the status of the
master branch.