### PR TITLE
Fix CI not catching Debug.todo usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "elm-format --validate . && elm-test",
+    "test": "elm-format --validate . && elm-test && parcel build index.html --public-url ./",
     "dev": "parcel index.html",
     "build": "parcel build index.html --public-url ./"
   },


### PR DESCRIPTION
Instead of simply running unit tests, we now also build the package in
production mode, to ensure that no usages of Debug.todo are to be found
before code is merged.