### PR TITLE
Deploy to rockin.app

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+rockin.app


### PR DESCRIPTION
The CNAME file allows the application to know at which url the built
website should be deployed. Unfortunately, GitHub Pages does not support
the usage of the www scheme, so we won't support it for now.