### PR TITLE
Fix the Travis CI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - 8
 
 after_success:
-  - yarn build
+  - yarn build && cp CNAME dist/CNAME
 
 deploy:
   provider: pages


### PR DESCRIPTION
There was a missing file in the distributed package for GitHub Pages.
This will now be fixed.