### PR TITLE
Disable CI on non upstream repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ deploy:
   local_dir: dist
   on:
     branch: master
+    repo: heig-PRO-b04/elm-frontend


### PR DESCRIPTION
Rather than having failing deployments on master branches of forks,
we'll instead have no deployment on these branches, to pass CI.