### PR TITLE
Run GitHub workflows on pull requests

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,5 @@
 name: Elm Format
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,5 @@
 name: Elm Unit Tests
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Currently, the workflows are only run on pushes to branches, not on pull requests. This should now be fixed.