### PR TITLE
Add a dedicated Task.execute method

### DIFF
--- a/src/Task/Extra.elm
+++ b/src/Task/Extra.elm
@@ -1,0 +1,20 @@
+module Task.Extra exposing (execute)
+
+import Task exposing (Task)
+
+
+{-| Tasks for which the error type matches the result type may be flattened
+when they are executed.
+-}
+execute : Task a a -> Cmd a
+execute task =
+    Task.attempt
+        (\result ->
+            case result of
+                Result.Ok x ->
+                    x
+
+                Result.Err x ->
+                    x
+        )
+        task


### PR DESCRIPTION
Some tasks are known to behave in the same way if they succeeed or if
they fail, and the return value of the execution of these tasks should
be defined as a single type.