### PR TITLE
Refine the polls display page

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,12 +11,12 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
             "elm/url": "1.0.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },

--- a/src/Cmd.elm
+++ b/src/Cmd.elm
@@ -1,5 +1,5 @@
 module Cmd exposing
-    ( withCmd, withNoCmd
+    ( withCmd, withNoCmd, succeed
     , initWith
     , updateWith
     )
@@ -10,7 +10,7 @@ everything that works with commands essentially.
 
 # Commands
 
-@docs withCmd, withNoCmd
+@docs withCmd, withNoCmd, succeed
 
 
 # Init

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -232,8 +232,15 @@ update msg model =
 
 
 subscriptions : Model -> Sub Message
-subscriptions _ =
-    Sub.none
+subscriptions model =
+    case model.page of
+        PollModel pollModel ->
+            Sub.map
+                PollMessage
+                (Poll.subscriptions pollModel)
+
+        _ ->
+            Sub.none
 
 
 changeRouteTo : Maybe Route -> Model -> ( Model, Cmd Message )

--- a/src/Page/Polls.elm
+++ b/src/Page/Polls.elm
@@ -158,7 +158,7 @@ viewHeaderRow : List (Html.Attribute msg) -> List (Html msg) -> Html msg
 viewHeaderRow attrs html =
     let
         base =
-            [ class "font-archivo text-gray-500 text-left tracking-wider border-gray-200"
+            [ class "font-archivo text-gray-500 text-left tracking-wider border-gray-200 select-none"
             , class "py-3"
             ]
     in

--- a/src/Page/Polls.elm
+++ b/src/Page/Polls.elm
@@ -2,6 +2,7 @@ module Page.Polls exposing
     ( Message
     , Model
     , init
+    , subscriptions
     , update
     , view
     )
@@ -16,6 +17,7 @@ import Route
 import Session exposing (Session, Viewer)
 import Task
 import Task.Extra
+import Time
 
 
 
@@ -69,6 +71,13 @@ update message model =
                         |> Task.mapError (always NowRequestPolls)
                         |> Task.Extra.execute
                     ]
+
+
+{-| Request polls refresh every 10 seconds.
+-}
+subscriptions : Model -> Sub Message
+subscriptions _ =
+    Time.every (10 * 1000) (always NowRequestPolls)
 
 
 

--- a/src/Page/Polls/Sorting.elm
+++ b/src/Page/Polls/Sorting.elm
@@ -1,0 +1,21 @@
+module Page.Polls.Sorting exposing
+    ( Order(..)
+    , ordering
+    )
+
+import Api.Polls as Api
+
+
+type Order
+    = TitleAsc
+    | TitleDes
+
+
+ordering : Order -> Api.Poll -> Api.Poll -> Basics.Order
+ordering order a b =
+    case order of
+        TitleAsc ->
+            compare a.title b.title
+
+        TitleDes ->
+            compare b.title a.title

--- a/static/icon/arrow-down.svg
+++ b/static/icon/arrow-down.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg"
+  version="1.1" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="#a0aec0" d="M11,4H13V16L18.5,10.5L19.92,11.92L12,19.84L4.08,11.92L5.5,10.5L11,16V4Z"/>
+</svg>

--- a/static/icon/arrow-up.svg
+++ b/static/icon/arrow-up.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg"
+  version="1.1" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="#a0aec0" d="M13,20H11V8L5.5,13.5L4.08,12.08L12,4.16L19.92,12.08L18.5,13.5L13,8V20Z"/>
+</svg>


### PR DESCRIPTION
- Add some nice status pills for the polls status. Defaults to **closed** for now.
- Automatically refresh the contents every 10 seconds, so that new polls added from a different client are displayed.
- Let the user sort the polls by ascending or descending title.