### PR TITLE
Persist authentication credentials in local storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,30 @@
 import { Elm } from "./src/Main.elm";
 
 // Maybe we will want to pass the API endpoint in the program flags.
+const storageKey = "credentials";
+
+const flags = localStorage.getItem(storageKey);
 const app = Elm.Main.init({
-  node: document.querySelector("main")
+  node: document.querySelector("main"),
+  flags: flags
+});
+
+
+
+app.ports.portStoreCredentials.subscribe(function (val) {
+  if (val == null) {
+    localStorage.removeItem(storageKey);
+  } else {
+    localStorage.setItem(storageKey, JSON.stringify(val));
+  }
+
+  setTimeout(function () {
+    app.ports.portSubscribeCredentials.send(val);
+  }, 0);
+});
+
+window.addEventListener("storage", function (event) {
+  if (event.storageArea === localStorage && event.key === storageKey) {
+    app.ports.portSubscribeCredentials.send(event.newValue);
+  }
 });

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,5 +1,6 @@
 module Main exposing (main)
 
+import Api
 import Browser
 import Browser.Navigation as Nav
 import Cmd exposing (initWith, updateWith, withCmd, withNoCmd)
@@ -93,11 +94,16 @@ toSession model =
             Session.toSession m.viewer
 
 
-init : () -> Url.Url -> Nav.Key -> ( Model, Cmd Message )
-init _ url key =
+init : Maybe Api.Credentials -> Url.Url -> Nav.Key -> ( Model, Cmd Message )
+init credentials url key =
     let
         session =
-            Session.guest key
+            case credentials of
+                Just unwrapped ->
+                    Session.guest key |> Session.withCredentials unwrapped
+
+                Nothing ->
+                    Session.guest key
 
         start =
             \model ->
@@ -314,9 +320,8 @@ changeRouteTo route model =
 -- APPLICATION
 
 
-main : Program () Model Message
 main =
-    Browser.application
+    Api.application
         { init = init
         , update = update
         , subscriptions = subscriptions

--- a/src/Page/Authenticate.elm
+++ b/src/Page/Authenticate.elm
@@ -131,7 +131,8 @@ update message model =
                         |> Session.withCredentials credentials
             }
                 |> withCmd
-                    [ Route.replaceUrl
+                    [ Api.storeCredentials credentials
+                    , Route.replaceUrl
                         (Session.sessionNavKey model.session)
                         Route.Polls
                     ]

--- a/src/Page/Logout.elm
+++ b/src/Page/Logout.elm
@@ -5,6 +5,7 @@ module Page.Logout exposing
     , view
     )
 
+import Api
 import Cmd exposing (withCmd, withNoCmd)
 import Html exposing (Html)
 import Route
@@ -18,7 +19,10 @@ type alias Model =
 init : Session -> ( Model, Cmd Never )
 init session =
     { session = Session.guest <| Session.sessionNavKey session }
-        |> withCmd [ Route.replaceUrl (Session.sessionNavKey session) Route.Home ]
+        |> withCmd
+            [ Api.storeCredentialsClear
+            , Route.replaceUrl (Session.sessionNavKey session) Route.Home
+            ]
 
 
 update : msg -> Model -> ( Model, Cmd Never )


### PR DESCRIPTION
This issue will fix #87.

A small note - the token is only retrieved on page reloads : if you log out on a separate tab, you will therefore still remain connected on the current tab until you close it (and the session is cleared from the model).