### PR TITLE
Add a Page and Route for credentials errors

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,6 +6,7 @@ import Browser.Navigation as Nav
 import Cmd exposing (initWith, updateWith, withCmd, withNoCmd)
 import Html
 import Page.Authenticate as Auth
+import Page.BadCredentials as Disc
 import Page.Home as Home
 import Page.Logout as Quit
 import Page.NewPoll as NewPoll
@@ -29,6 +30,7 @@ type alias Model =
 type PageModel
     = AuthModel Auth.Model
     | HomeModel Home.Model
+    | DiscModel Disc.Model
     | QuitModel Quit.Model
     | PollModel Poll.Model
     | NewPollModel NewPoll.Model
@@ -82,6 +84,9 @@ toSession model =
             m.session
 
         HomeModel m ->
+            m.session
+
+        DiscModel m ->
             m.session
 
         QuitModel m ->
@@ -139,6 +144,10 @@ view model =
                     Home.view homeModel
                         |> List.map (Html.map HomeMessage)
 
+                DiscModel discModel ->
+                    Disc.view discModel
+                        |> List.map (Html.map DiscMessage)
+
                 QuitModel quitModel ->
                     Quit.view quitModel
                         |> List.map (Html.map never)
@@ -165,6 +174,7 @@ type Message
     | ClickedLink Browser.UrlRequest
     | NavUIMessage NavUI.Message
     | HomeMessage Home.Message
+    | DiscMessage Disc.Message
     | AuthMessage Auth.Message
     | PollMessage Poll.Message
     | NewPollMessage NewPoll.Message
@@ -216,6 +226,14 @@ update msg model =
                 Home.update
                 homeMsg
                 homeModel
+
+        ( DiscMessage discMsg, DiscModel discModel ) ->
+            updateWith
+                DiscMessage
+                (embed model DiscModel)
+                Disc.update
+                discMsg
+                discModel
 
         ( PollMessage pollMsg, PollModel pollModel ) ->
             updateWith
@@ -292,6 +310,12 @@ changeRouteTo route model =
                 never
                 (embed newModel QuitModel)
                 (Quit.init session)
+
+        Just Route.BadCredentials ->
+            initWith
+                DiscMessage
+                (embed newModel DiscModel)
+                (Disc.init session)
 
         Just Route.Polls ->
             case Session.toViewer session of

--- a/src/Page/BadCredentials.elm
+++ b/src/Page/BadCredentials.elm
@@ -1,0 +1,54 @@
+module Page.BadCredentials exposing (..)
+
+import Cmd exposing (withCmd)
+import Html exposing (Html, br, div, text)
+import Html.Attributes exposing (class)
+import Process
+import Route
+import Session exposing (Session)
+import Task
+import Task.Extra
+
+
+type alias Model =
+    { session : Session }
+
+
+type Message
+    = Redirect
+
+
+init : Session -> ( Model, Cmd Message )
+init session =
+    { session = session }
+        |> withCmd
+            [ Process.sleep (85 * 100)
+                |> Task.andThen (\_ -> Task.succeed Redirect)
+                |> Task.Extra.execute
+            ]
+
+
+update : Message -> Model -> ( Model, Cmd Message )
+update message model =
+    case message of
+        Redirect ->
+            model
+                |> withCmd
+                    [ Route.replaceUrl
+                        (Session.sessionNavKey model.session)
+                        Route.Logout
+                    ]
+
+
+view : Model -> List (Html Message)
+view _ =
+    [ div
+        [ class "m-auto max-w-lg bg-white px-8 py-4 my-8 shadow-xl rounded-lg"
+        , class "font-archivo font-semibold text-3xl"
+        ]
+        [ text "Gosh, your login info is not valid anymore ⏳"
+        , br [] []
+        , br [] []
+        , text "Going back Home 🚀"
+        ]
+    ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,5 +1,6 @@
 module Route exposing
     ( Route(..)
+    , badCredentials
     , fromUrl
     , href
     , replaceUrl
@@ -17,6 +18,7 @@ type Route
     | Login
     | Registration
     | Logout
+    | BadCredentials
     | Polls
     | NewPoll
 
@@ -40,6 +42,14 @@ replaceUrl key route =
     Nav.replaceUrl key (routeToString route)
 
 
+{-| Performs navigation to a page that lets the user know that they currently have some bad
+credentials, and automatically disconnects them.
+-}
+badCredentials : Nav.Key -> Cmd msg
+badCredentials key =
+    replaceUrl key BadCredentials
+
+
 
 -- PARSER
 
@@ -52,6 +62,7 @@ parser =
         , Parser.map Home (s "home")
         , Parser.map Registration (s "register")
         , Parser.map Logout (s "logout")
+        , Parser.map BadCredentials (s "disconnected")
         , Parser.map Polls (s "polls")
         , Parser.map NewPoll (s "newpoll")
         ]
@@ -80,6 +91,9 @@ routeToPieces page =
 
         Logout ->
             [ "logout" ]
+
+        BadCredentials ->
+            [ "disconnected" ]
 
         Polls ->
             [ "polls" ]


### PR DESCRIPTION
This commit will fix #83. The page can then act as a destination if the API calls indicate that there way a credential error when talking to the API.